### PR TITLE
Fix Blacklist bug of IP contained in other one

### DIFF
--- a/api/osd_blacklist_ls.go
+++ b/api/osd_blacklist_ls.go
@@ -15,7 +15,8 @@ type OsdBlacklistLs struct {
 func (obl *OsdBlacklistLs) IsInBlacklist(ip string) bool {
 	for _, node := range obl.Nodes {
 		// luminous adds client specific bans, only consider whole node ban ending in "0/0"
-		if strings.Contains(node.Addr, ip) && strings.HasSuffix(node.Addr, ":0/0") {
+		blacklistIp := strings.Split(node.Addr, ":")
+		if blacklistIp[0] == ip && blacklistIp[1] == "0/0" {
 			return true
 		}
 	}

--- a/api/osd_blacklist_ls_test.go
+++ b/api/osd_blacklist_ls_test.go
@@ -18,3 +18,14 @@ func TestIsInBlackList(t *testing.T) {
 	assert.True(t, obl.IsInBlacklist("1.2.3.4"))
 	assert.False(t, obl.IsInBlacklist("10.160.10.102"))
 }
+
+func TestIsInBlackListAndContained(t *testing.T) {
+	var obl OsdBlacklistLs
+	body := `{"status": "listed 1 entries", "output": [{"addr": "1.2.3.40:0/0", "until": "2018-04-05 10:36:29.496087"},{"addr": "10.160.10.102:0/1708448121", "until": "2018-01-03 19:44:08.080229"}]}`
+	err := json.Unmarshal([]byte(body), &obl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, obl.IsInBlacklist("1.2.3.4"))
+}


### PR DESCRIPTION
# Summary
Method **IsInBlacklist** in library [go-ceph|https://github.com/medallia/go-ceph] is using the string.Contains method to check if a node (IP) is blacklisted.

Since the IP comparison is made with a string.Contains if the IP to be searched is contained in another IP, the method will return a false positive:

|**Node**|**IP**|**Blacklisted**|
|:----------:|:------:|:-------------:|
|ger-r14-u01|10.160.14.6|No|
|ger-r14-u25|10.160.14.62|Yes|

It is worth saying that this only can happens with nodes in units 1 to 5, since unit 6 maps to octet 26 and octets can't be greater than 255. 

# Solution
The *IsInBlacklist* method needs to split the string containing the blacklist information and do a full IP comparsion to check if the node is the one blacklisted

# Tests
Fix was added and a new test (TestIsInBlackListAndContained) was added. Code was tested with and without the fix to check that it is fully working:

## Without Fix
```
root@8240cd14accb:/go/src/github.com/ceph/go-ceph# /usr/lib/go-1.10/bin/go test -v github.com/ceph/go-ceph/api
=== RUN   TestIsInBlackList
--- PASS: TestIsInBlackList (0.00s)
=== RUN   TestIsInBlackListAndContained
--- FAIL: TestIsInBlackListAndContained (0.00s)
	osd_blacklist_ls_test.go:30:
			Error Trace:	osd_blacklist_ls_test.go:30
			Error:      	Should be false
			Test:       	TestIsInBlackListAndContained
FAIL
FAIL	github.com/ceph/go-ceph/api	0.006s
```

## With Fix
```
root@8240cd14accb:/go/src/github.com/ceph/go-ceph# /usr/lib/go-1.10/bin/go test -v github.com/ceph/go-ceph/api
=== RUN   TestIsInBlackList
--- PASS: TestIsInBlackList (0.00s)
=== RUN   TestIsInBlackListAndContained
--- PASS: TestIsInBlackListAndContained (0.00s)
```
