### PR TITLE
CIF-1246: Change go-ceph Client to hashicorp retryablehttp

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -35,6 +35,7 @@ func (cc *CephClient) callApi(endpoint string, method string) (string, error) {
 	client.RetryWaitMax = 2 * time.Minute
 	client.RetryMax = 5
 	client.HTTPClient.Timeout = 30 * time.Second
+	client.Logger = &CustomLogger{}
 
 	req, err := retryablehttp.NewRequest(method, endpoint, nil)
 	if err != nil {


### PR DESCRIPTION
# Summary
With this change, users of go-ceph (like Autopilot) will be able to automatically do retries to a specific API call if it fails. The timeout of an API call remains as it was before the change: 5 minutes. The backoff algorithm used is the default given by the library and the retries values are set to:
* MinWait: 5 seconds
* MaxWait: 2 minutes
* Retries: 5

## Library log
Retryable HTTP lib logs every API call made and this can be kind of annoying. The interface provided only let the user use the **Printf** method, which means that no logging level can be specified to avoid logging DEBUG logs. 

As a quick workaround, a CustomLogger was created that filters all messages that are not ERR logs.